### PR TITLE
Add advanced trading features to DEXs, e.g. stop losses/buys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Modifications
+This is a fork of the Cosmos DEX for the Cosmos DeFi hackathon at SF Blockchain Week 2019, for which we came 4th overall out of 50 or so teams. This is one of the 2 submitted projects, which adds the ability to do things in the future to a DEX, which is part of my overall idea for 'Active Smart Contracts' (ASCs). The general problem being solved is that blockchains are passive and require a user to submit a transaction every time they want to do something on-chain. In terms of trading, this requires a user to be online 24/7 or have a bot trading for them because trades almost always depend on certain conditions: limit orders, stop losses etc. This lack of basic trading features puts DEXs far behind CEXs in terms of usability and is severely inhibiting the growth of the DEX space. A user needs to be able to set some conditions for some actions (if the price of X token falls below Y value, buy etc) in the future, go offline, and have those actions executed under the right conditions.
+
+The solution to allow actions on a blockchain to happen in the future is a cryptoeconomic one - essentially incentivising others to submit your transactions under certain conditions for you. In Cosmos, however, you can 'register' events to happen at the end of every block. I added a new type of action here, a stop loss, which constantly checks the registered stop losses to see if any of the conditions are true which enable them to be executed.
+
+The rest of this README is the original.
+
+
+
+
+
+
 # Disclaimer
 
 The code hosted in this repository is a **technology preview** and is suitable for **demo purposes only**. The features provided by this draft implementation are not meant to be functionally complete and are not suitable for deployment in production.

--- a/app/app.go
+++ b/app/app.go
@@ -148,7 +148,7 @@ func NewDexApp(
 		bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
 		supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
 		params.StoreKey, assettypes.StoreKey, markettypes.StoreKey,
-		ordertypes.StoreKey,
+		ordertypes.StoreKey, ordertypes.LastPriceKey,
 	)
 	tkeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
@@ -199,6 +199,7 @@ func NewDexApp(
 		app.MarketKeeper,
 		app.AssetKeeper,
 		keys[ordertypes.StoreKey],
+		keys[ordertypes.LastPriceKey],
 		queue,
 		app.Cdc,
 	)

--- a/x/order/client/cli/cli.go
+++ b/x/order/client/cli/cli.go
@@ -24,6 +24,7 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		Short: "manages orders",
 	}
 	txCmd.AddCommand(client.PostCommands(
+		GetCmdStop(cdc),
 		GetCmdPost(cdc),
 		GetCmdCancel(cdc),
 	)...)

--- a/x/order/client/cli/tx.go
+++ b/x/order/client/cli/tx.go
@@ -17,6 +17,67 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+func GetCmdStop(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop [market-id] [direction] [price] [quantity] [time-in-force-blocks] [init-price] [relayer-address-hex] [relayer-fee]",
+		Short: "posts an order under certain price conditions, i.e. a stop-loss or stop-buy",
+		Args:  cobra.ExactArgs(8),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, bldr, err := cliutil.BuildEnsuredCtx(cdc)
+			if err != nil {
+				return err
+			}
+
+			marketID := store.NewEntityIDFromString(args[0])
+			var direction matcheng.Direction
+			dirArg := strings.ToLower(args[1])
+			if dirArg == "bid" {
+				direction = matcheng.Bid
+			} else if dirArg == "ask" {
+				direction = matcheng.Ask
+			} else {
+				return errors.New("invalid direction")
+			}
+
+			price, err := sdk.ParseUint(args[2])
+			if err != nil {
+				return err
+			}
+			quantity, err := sdk.ParseUint(args[3])
+			if err != nil {
+				return err
+			}
+			tif, err := strconv.ParseUint(args[4], 10, 64)
+			if err != nil {
+				return err
+			}
+			if tif > math.MaxUint16 {
+				return errors.New("time in force too large")
+			}
+
+			initPrice, err := sdk.ParseUint(args[5])
+			if err != nil {
+				return err
+			}
+			relayedAddress, err := sdk.AccAddressFromHex(args[6])
+			if err != nil {
+				return err
+			}
+			err = sdk.VerifyAddressFormat(relayedAddress)
+			if err != nil {
+				return errors.New("invalid address format")
+			}
+			relayerFee, err := sdk.ParseCoins(args[7])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgStop(ctx.GetFromAddress(), marketID, direction, price, quantity, uint16(tif), initPrice, relayedAddress, relayerFee)
+			return cliutil.ValidateAndBroadcast(ctx, bldr, msg)
+		},
+	}
+}
+
 func GetCmdPost(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "post [market-id] [direction] [price] [quantity] [time-in-force-blocks]",

--- a/x/order/client/cli/tx.go
+++ b/x/order/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -23,7 +24,7 @@ func GetCmdStop(cdc *codec.Codec) *cobra.Command {
 		Short: "posts an order under certain price conditions, i.e. a stop-loss or stop-buy",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, bldr, err := cliutil.BuildEnsuredCtx(cdc)
+			ctx, _, err := cliutil.BuildEnsuredCtx(cdc)
 			if err != nil {
 				return err
 			}
@@ -73,7 +74,8 @@ func GetCmdStop(cdc *codec.Codec) *cobra.Command {
 			}
 
 			msg := types.NewMsgStop(ctx.GetFromAddress(), marketID, direction, price, quantity, uint16(tif), initPrice, relayedAddress, relayerFee)
-			return cliutil.ValidateAndBroadcast(ctx, bldr, msg)
+			fmt.Println(msg)
+			return nil
 		},
 	}
 }

--- a/x/order/handler.go
+++ b/x/order/handler.go
@@ -15,6 +15,8 @@ var logger = log.WithModule("order")
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
+		case types.MsgStop:
+			return handleMsgStop(ctx, keeper, msg)
 		case types.MsgPost:
 			return handleMsgPost(ctx, keeper, msg)
 		case types.MsgCancel:
@@ -22,6 +24,59 @@ func NewHandler(keeper Keeper) sdk.Handler {
 		default:
 			return sdk.ErrUnknownRequest(fmt.Sprintf("unknown message type %v", msg.Type())).Result()
 		}
+	}
+}
+
+func handleMsgStop(ctx sdk.Context, keeper Keeper, msg types.MsgStop) sdk.Result {
+	currentPrice := sdk.NewUint(0)
+	// Shouldn't be triggered in these ranges
+	if msg.Post.Price.GT(msg.PastPrice) && currentPrice.LT(msg.Post.Price) {
+		return sdk.Result{
+			Log: fmt.Sprintf("current price not in triggering range"),
+		}
+	}
+	if msg.Post.Price.LT(msg.PastPrice) && currentPrice.GT(msg.Post.Price) {
+		return sdk.Result{
+			Log: fmt.Sprintf("current price not in triggering range"),
+		}
+	}
+
+	order, err := keeper.Post(
+		ctx,
+		msg.Post.Owner,
+		msg.Post.MarketID,
+		msg.Post.Direction,
+		msg.Post.Price,
+		msg.Post.Quantity,
+		msg.Post.TimeInForce,
+	)
+	if err != nil {
+		return err.Result()
+	}
+	logger.Info(
+		"stop order",
+		"id", order.ID.String(),
+		"market_id", order.MarketID.String(),
+		"price", order.Price.String(),
+		"quantity", order.Quantity.String(),
+		"direction", order.Direction.String(),
+	)
+
+	err = keeper.bankKeeper.SendCoins(ctx, msg.Post.Owner, msg.Relayer, msg.RelayFee)
+	if err == nil {
+		return err.Result()
+	}
+	logger.Info(
+		"stop order",
+		"id", order.ID.String(),
+		"market_id", order.MarketID.String(),
+		"price", order.Price.String(),
+		"quantity", order.Quantity.String(),
+		"direction", order.Direction.String(),
+	)
+
+	return sdk.Result{
+		Log: fmt.Sprintf("order_id:%s", order.ID),
 	}
 }
 

--- a/x/order/handler.go
+++ b/x/order/handler.go
@@ -28,14 +28,14 @@ func NewHandler(keeper Keeper) sdk.Handler {
 }
 
 func handleMsgStop(ctx sdk.Context, keeper Keeper, msg types.MsgStop) sdk.Result {
-	currentPrice := sdk.NewUint(0)
+	currentPrice := keeper.GetPrice(ctx, msg.Post.MarketID)
 	// Shouldn't be triggered in these ranges
-	if msg.Post.Price.GT(msg.PastPrice) && currentPrice.LT(msg.Post.Price) {
+	if msg.Post.Price.GT(msg.InitPrice) && currentPrice.LT(msg.Post.Price) {
 		return sdk.Result{
 			Log: fmt.Sprintf("current price not in triggering range"),
 		}
 	}
-	if msg.Post.Price.LT(msg.PastPrice) && currentPrice.GT(msg.Post.Price) {
+	if msg.Post.Price.LT(msg.InitPrice) && currentPrice.GT(msg.Post.Price) {
 		return sdk.Result{
 			Log: fmt.Sprintf("current price not in triggering range"),
 		}

--- a/x/order/keeper.go
+++ b/x/order/keeper.go
@@ -26,16 +26,18 @@ type Keeper struct {
 	marketKeeper market.Keeper
 	assetKeeper  asset.Keeper
 	storeKey     sdk.StoreKey
+	latestPrices sdk.StoreKey
 	queue        types.Backend
 	cdc          *codec.Codec
 }
 
-func NewKeeper(bk bank.Keeper, mk market.Keeper, ak asset.Keeper, sk sdk.StoreKey, queue types.Backend, cdc *codec.Codec) Keeper {
+func NewKeeper(bk bank.Keeper, mk market.Keeper, ak asset.Keeper, lp, sk sdk.StoreKey, queue types.Backend, cdc *codec.Codec) Keeper {
 	return Keeper{
 		bankKeeper:   bk,
 		marketKeeper: mk,
 		assetKeeper:  ak,
 		storeKey:     sk,
+		latestPrices: lp,
 		queue:        queue,
 		cdc:          cdc,
 	}
@@ -205,3 +207,5 @@ func (k Keeper) doIterator(iter sdk.Iterator, cb IteratorCB) {
 func orderKey(id store.EntityID) []byte {
 	return store.PrefixKeyString(valKey, id.Bytes())
 }
+
+func (k Keeper) SetPrice(ctx sdk.Context, )

--- a/x/order/keeper.go
+++ b/x/order/keeper.go
@@ -31,7 +31,7 @@ type Keeper struct {
 	cdc          *codec.Codec
 }
 
-func NewKeeper(bk bank.Keeper, mk market.Keeper, ak asset.Keeper, lp, sk sdk.StoreKey, queue types.Backend, cdc *codec.Codec) Keeper {
+func NewKeeper(bk bank.Keeper, mk market.Keeper, ak asset.Keeper, sk, lp sdk.StoreKey, queue types.Backend, cdc *codec.Codec) Keeper {
 	return Keeper{
 		bankKeeper:   bk,
 		marketKeeper: mk,
@@ -208,4 +208,17 @@ func orderKey(id store.EntityID) []byte {
 	return store.PrefixKeyString(valKey, id.Bytes())
 }
 
-func (k Keeper) SetPrice(ctx sdk.Context, )
+func (k Keeper) SetPrice(ctx sdk.Context, mID store.EntityID, price sdk.Uint) {
+	store := ctx.KVStore(k.latestPrices)
+	mn := mID.String()
+	stringPrice := price.String()
+	store.Set([]byte(mn), []byte(stringPrice))
+}
+
+func (k Keeper) GetPrice(ctx sdk.Context, mID store.EntityID) sdk.Uint {
+	store := ctx.KVStore(k.latestPrices)
+	mn := mID.String()
+	currentPriceBytes := store.Get([]byte(mn))
+	currentPriceString := string(currentPriceBytes)
+	return sdk.NewUintFromString(currentPriceString)
+}

--- a/x/order/types/codec.go
+++ b/x/order/types/codec.go
@@ -5,6 +5,7 @@ import "github.com/cosmos/cosmos-sdk/codec"
 var ModuleCdc = codec.New()
 
 func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgStop{}, "order/Stop", nil)
 	cdc.RegisterConcrete(MsgPost{}, "order/Post", nil)
 	cdc.RegisterConcrete(MsgCancel{}, "order/Cancel", nil)
 }

--- a/x/order/types/types.go
+++ b/x/order/types/types.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	ModuleName = "order"
-	RouterKey  = ModuleName
-	StoreKey   = ModuleName
+	ModuleName   = "order"
+	RouterKey    = ModuleName
+	StoreKey     = ModuleName
+	LastPriceKey = "last_price"
 )
 
 const MaxTimeInForce = 600


### PR DESCRIPTION
Currently on-chain DEXs lack any features other than basic orders. This is a significant source of friction for transitioning users from centralised exchanges to decentralised ones because people can't use their regular trading strategies. Simple things like stop losses are impossible in current DEXs because smart contracts/blockchains are passive (they only change their state when someone interacts with them), so a user needs to be online in order to push an order through.

This solution uses the ASC (Active Smart Contract/Active State Changer) Protocol to make a smart contract (Eth etc), or, in this case, a Cosmos module, active in the sense that a user can set some action to happen in the future then go offline forever and the state change will still happen in the future while the user is offline. This allows users to set up subscription payments that don't require them to manually sign something every month, advanced trading functionality, auto-closing of a user's own MakerDAO CDP that's close to being undercollateralised, investment/insurance funds that automatically pay out to users, and even allows smart contracts/modules to autonomously enact changes in the physical world by using services such as Chainlink on their own. All that is required is the use of the ASC Protocol and tokens to be locked up to fund the contracts' tx fees.

Technically the contract/module still requires txs from people to enact the changes it wants to cause, but those txs can be called by anyone and are incentivised by the contract/module paying out a small reward to whoever calls them and are therefore economically guaranteed. In the same sense that the concept of a Bitcoin is an abstraction of UTXOs, ASCs are an abstraction of incentivised txs.

In this PR I have added a `Stop` message type to orders. It basically wraps `Post` but adds a condition that makes it fail if the most recent price of the relevant coin is outside the range of values that the stop should be called in. Before going offline, the user can give this transaction to someone (a `relayer`) who will profit from broadcasting the transaction at the correct time by giving a specified amount of coins to the relayer upon successful execution of the trade. The user is therefore economically guaranteed that their transaction will execute as soon as the stop condition is met because game theoretically, the relayer's best choice to maximise profit is to execute it as soon as it will succeed because there may never be a time in the future when the same condition will be met again and therefore impossible for the relayer to profit.

Transaction flow:
 - The user finds a relayer, ideally through a web-market of relayers that have each publicly stated they are willing to hold onto transactions for competing fee rates, such as a stop loss, and watch the relevant price data until they are able to fulfill the condition of the trade
 - The user signs a `Stop` transaction but does not broadcast it to the wider network
 - The user privately sends the signed transaction in raw hex format to the chosen relayer through their chosen channel, who then stores the tx locally
 - The relayer watches the relevant price
 - When the market price goes above or below the stop price (depending on `initPrice`), the transaction is able to be executed, so the relayer broadcasts the tx to the wider network
 - The tx is executed successfully. The user has bought or sold around their desired price. Cancer is cured. There is peace in the Middle East. World hunger is no more.

Notes:
 - This application of the ASC Protocol is clunky and specific to implementing stop losses here in this DEX and was done in a way that was mainly chosen for ease of use and speed for me as a hackathon project who only started to read any Cosmos code about 14 hours before this PR was submitted. The much more generalised implementation is A) to have a GSN-like network of nodes who basically run a service of having a 2nd mempool (for arbitrarily many blockchains) that is constantly checked to see if the txs can be executed, B) done in a way that the relayer is the one who signs the tx so that it's impossible for the relayed to grief the user by prematurely sending the tx
 - The stop loss is private to everyone except the person who will execute it, like regular centralised exchanges
 - The worst case scenario for the user is that the relayer broadcasts the trade prematurely and therefore the user loses a small tx fee from the tx failing. The user can then blacklist that relayer if they come back online and notice the trade wasn't executed despite the conditions having been fulfilled at some point while the user was offline.
 - It can be used for stop-losses or stop-buys in any direction
 - I didn't use `start-block` and `end-block` because there is an attack vector for filling one of those will junk txs that will never execute and forcing them to be checked every block for the rest of time for very little gas cost